### PR TITLE
chore(ci)!: only build linux binaries with latest `glibc`

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -67,11 +67,11 @@ jobs:
           - archive: gdpack-${{ needs.release-please.outputs.release-tag }}-linux-x86_64.tar.gz
             target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
-            use_cross: true
+            use_cross: false
           - archive: gdpack-${{ needs.release-please.outputs.release-tag }}-linux-arm64.tar.gz
             target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
-            use_cross: true
+            use_cross: false
 
           # Windows
           - archive: gdpack-${{ needs.release-please.outputs.release-tag }}-windows-x86_64.zip


### PR DESCRIPTION
Targeting earlier versions causes an error accessing `git` database files. Postpone debugging and just build with latest `glibc` of runners.